### PR TITLE
Corrige permissão da action gerar_venda e documenta mapeamento do dropdown

### DIFF
--- a/api/permissions.py
+++ b/api/permissions.py
@@ -45,6 +45,8 @@ class SolicitacaoCreditoPermission(BasePermission):
             "informar_imei_analise",
         ):
             return user.has_perm("vendas.change_status_analise") or user.has_perm("vendas.change_cliente")
+        if action == "gerar_venda":
+            return user.has_perm("vendas.add_venda")
         if action == "destroy":
             return user.has_perm("vendas.delete_cliente")
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -322,7 +322,22 @@ Gera venda a partir da solicitacao, seguindo as mesmas regras do fluxo existente
 - caixa aberto
 - cria venda, produto_venda, pagamentos e parcelas
 
+Permissao minima:
+
+- `vendas.add_venda`
+
 Payload: vazio.
+
+### Mapeamento do dropdown da tela de clientes (fluxo de solicitacao)
+
+Itens do dropdown enviado no front correspondem aos seguintes endpoints da API:
+
+- `Configurar iCloud (Vendedor)` → `POST /api/solicitacoes/{cliente_id}/configurar-icloud/`
+- `Confirmar iCloud (Analista)` → `POST /api/solicitacoes/{cliente_id}/analista-confirm-icloud/`
+- `Informar IMEI (Analista)` → `POST /api/solicitacoes/analises/{analise_id}/informar-imei/`
+- `Confirmar Leitura QR (Vendedor)` → `POST /api/solicitacoes/{cliente_id}/confirmar-app/`
+- `Confirmar Instalacao (Analista)` → `POST /api/solicitacoes/{cliente_id}/analista-confirmar-instalacao/`
+- `Gerar Venda (Vendedor)` → `POST /api/solicitacoes/{cliente_id}/gerar-venda/`
 
 ## Produtos
 


### PR DESCRIPTION
### Motivation
- A action `gerar_venda` do `SolicitacaoCreditoViewSet` não estava contemplada na `SolicitacaoCreditoPermission`, podendo provocar 403 para usuários que deveriam gerar vendas via API. 
- É necessário também documentar o mapeamento entre os itens do dropdown da tela de clientes (fluxos iPhone/Android) e os endpoints correspondentes da API para facilitar integração front↔API.

### Description
- Adicionada verificação de permissão para a action `gerar_venda` em `api/permissions.py`, exigindo a permissão `vendas.add_venda`.
- Atualizada `docs/API.md` para incluir a permissão mínima da rota `POST /api/solicitacoes/{cliente_id}/gerar-venda/` e um mapeamento explícito dos itens do dropdown da tela de clientes para os endpoints da API.

### Testing
- Verificações de presença/links no código com `rg` para actions/endpoints (procura por `analista_confirm_icloud`, `analista_confirm_installed`, `informar_imei_analise`, `gerar_venda`, etc.) foram executadas com sucesso.
- Executado `python manage.py check` no ambiente, que falhou devido à ausência do pacote `django` no ambiente (`ModuleNotFoundError: No module named 'django'`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d2f264cf4832a815dc0d72310ac4d)