### PR TITLE
API Loja: repasses endpoint, flags de acesso e detalhes de usuários

### DIFF
--- a/api/permissions.py
+++ b/api/permissions.py
@@ -14,6 +14,8 @@ class LojaPermission(BasePermission):
             return user.has_perm("vendas.add_loja")
         if action in ("update", "partial_update", "replicar_qrcode"):
             return user.has_perm("vendas.change_loja")
+        if action == "repasses":
+            return user.has_perm("financeiro.view_repasse") or user.has_perm("financeiro.add_repasse")
         if action == "destroy":
             return user.has_perm("vendas.delete_loja")
 

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -15,9 +15,32 @@ from vendas.models import ProdutoVenda, Pagamento
 
 
 class LojaSerializer(serializers.ModelSerializer):
+    usuarios_detalhes = serializers.SerializerMethodField()
+    gerentes_detalhes = serializers.SerializerMethodField()
+
     class Meta:
         model = Loja
         fields = "__all__"
+
+    def get_usuarios_detalhes(self, obj):
+        return [
+            {
+                "id": usuario.id,
+                "nome": usuario.get_full_name() or usuario.username,
+                "email": usuario.email,
+            }
+            for usuario in obj.usuarios.all()
+        ]
+
+    def get_gerentes_detalhes(self, obj):
+        return [
+            {
+                "id": gerente.id,
+                "nome": gerente.get_full_name() or gerente.username,
+                "email": gerente.email,
+            }
+            for gerente in obj.gerentes.all()
+        ]
 
     def validate(self, attrs):
         request = self.context.get("request")
@@ -47,6 +70,23 @@ class RepasseSerializer(serializers.ModelSerializer):
     class Meta:
         model = Repasse
         fields = ["id", "valor", "data", "status", "observacao", "criado_por", "criado_em"]
+
+
+class RepasseCreateSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Repasse
+        fields = ["valor", "data", "status", "observacao"]
+
+    def create(self, validated_data):
+        request = self.context["request"]
+        loja = self.context["loja"]
+        user = request.user
+        return Repasse.objects.create(
+            loja=loja,
+            criado_por=user,
+            atualizado_por=user,
+            **validated_data,
+        )
 
 
 class VendaSerializer(serializers.ModelSerializer):

--- a/api/tests.py
+++ b/api/tests.py
@@ -1,3 +1,69 @@
-from django.test import TestCase
+from django.contrib.auth.models import Permission
+from django.urls import reverse
+from django.utils import timezone
+from rest_framework import status
+from rest_framework.test import APITestCase
 
-# Create your tests here.
+from accounts.models import User
+from financeiro.models import Repasse
+from vendas.models import Loja
+
+
+class LojaApiTestCase(APITestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(username="tester", email="tester@example.com", password="123456")
+        self.loja = Loja.objects.create(nome="Loja API")
+        self.loja.usuarios.add(self.user)
+
+    def _add_perm(self, app_label, codename):
+        perm = Permission.objects.get(content_type__app_label=app_label, codename=codename)
+        self.user.user_permissions.add(perm)
+
+    def test_loja_retrieve_exibe_flags_de_acesso_e_bloqueia_repasses_sem_permissao(self):
+        self._add_perm("vendas", "view_loja")
+        self.client.force_authenticate(self.user)
+
+        url = reverse("loja-detail", args=[self.loja.id])
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn("acessos", response.data)
+        self.assertFalse(response.data["acessos"]["pode_ver_repasse"])
+        self.assertEqual(response.data["repasses"]["count"], 0)
+
+    def test_loja_repasses_endpoint_respeita_permissoes(self):
+        self._add_perm("vendas", "view_loja")
+        self.client.force_authenticate(self.user)
+        repasses_url = reverse("loja-repasses", args=[self.loja.id])
+
+        forbidden_response = self.client.get(repasses_url)
+        self.assertEqual(forbidden_response.status_code, status.HTTP_403_FORBIDDEN)
+
+        self._add_perm("financeiro", "view_repasse")
+        criador = User.objects.create_user(username="finance", email="finance@example.com", password="123456")
+        Repasse.objects.create(
+            loja=self.loja,
+            valor="120.00",
+            data=timezone.now(),
+            status="pendente",
+            criado_por=criador,
+            atualizado_por=criador,
+        )
+
+        allowed_response = self.client.get(repasses_url)
+        self.assertEqual(allowed_response.status_code, status.HTTP_200_OK)
+        self.assertEqual(allowed_response.data["count"], 1)
+
+        self._add_perm("financeiro", "add_repasse")
+        create_response = self.client.post(
+            repasses_url,
+            {
+                "valor": "250.00",
+                "data": timezone.now().isoformat(),
+                "status": "pendente",
+                "observacao": "repasse api",
+            },
+            format="json",
+        )
+        self.assertEqual(create_response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(Repasse.objects.filter(loja=self.loja).count(), 2)

--- a/api/views.py
+++ b/api/views.py
@@ -67,6 +67,7 @@ from .serializers import (
     LojaSerializer,
     ProdutoSerializer,
     VendaSerializer,
+    RepasseCreateSerializer,
     RepasseSerializer,
     SolicitacaoCreditoInputSerializer,
     SolicitacaoImeiTelefoneInputSerializer,
@@ -246,7 +247,10 @@ class LojaViewSet(viewsets.ModelViewSet):
         di = parse_date(data_inicio) if data_inicio else None
         df = parse_date(data_fim) if data_fim else None
 
-        repasses_qs = Repasse.objects.filter(loja=loja).select_related("criado_por")
+        can_view_repasse = request.user.has_perm("financeiro.view_repasse")
+        can_create_repasse = request.user.has_perm("financeiro.add_repasse")
+
+        repasses_qs = Repasse.objects.filter(loja=loja).select_related("criado_por") if can_view_repasse else Repasse.objects.none()
         repasse_paginator = Paginator(repasses_qs, 10)
         repasse_page = repasse_paginator.get_page(request.query_params.get("repasse_page"))
 
@@ -262,13 +266,16 @@ class LojaViewSet(viewsets.ModelViewSet):
         venda_paginator = Paginator(vendas_qs.order_by("-data_venda"), 10)
         venda_page = venda_paginator.get_page(request.query_params.get("venda_page"))
 
-        status_list, _ = loja.get_repasses_status(meses_atras=1)
-        if di:
-            status_list = [r for r in status_list if r["data"] >= di]
-        if df:
-            status_list = [r for r in status_list if r["data"] <= df]
+        status_list = []
+        repasse_atrasados = 0
+        if can_view_repasse:
+            status_list, _ = loja.get_repasses_status(meses_atras=1)
+            if di:
+                status_list = [r for r in status_list if r["data"] >= di]
+            if df:
+                status_list = [r for r in status_list if r["data"] <= df]
 
-        repasse_atrasados = sum(1 for r in status_list if not r["feito"] and r["data"] < date.today())
+            repasse_atrasados = sum(1 for r in status_list if not r["feito"] and r["data"] < date.today())
         kpi_valor_repasse = loja.calcular_valor_repasse(di, df)
 
         payload = {
@@ -297,9 +304,47 @@ class LojaViewSet(viewsets.ModelViewSet):
                 "valor_total": valor_total,
                 "valor_repasse": kpi_valor_repasse,
             },
+            "acessos": {
+                "pode_editar_loja": request.user.has_perm("vendas.change_loja"),
+                "pode_criar_repasse": can_create_repasse,
+                "pode_ver_repasse": can_view_repasse,
+                "can_view_all_stores": request.user.has_perm("vendas.can_view_all_stores"),
+            },
         }
 
         return Response(payload)
+
+    @action(detail=True, methods=["get", "post"], url_path="repasses")
+    @extend_schema(
+        request=RepasseCreateSerializer,
+        responses={200: RepasseSerializer(many=True), 201: RepasseSerializer, 403: OpenApiTypes.OBJECT},
+    )
+    def repasses(self, request, pk=None):
+        loja = self.get_object()
+
+        if request.method == "GET":
+            if not request.user.has_perm("financeiro.view_repasse"):
+                return Response({"detail": "Sem permissao para visualizar repasses."}, status=status.HTTP_403_FORBIDDEN)
+
+            repasses_qs = Repasse.objects.filter(loja=loja).select_related("criado_por")
+            paginator = Paginator(repasses_qs, 10)
+            page = paginator.get_page(request.query_params.get("repasse_page"))
+            return Response(
+                {
+                    "count": paginator.count,
+                    "num_pages": paginator.num_pages,
+                    "page": page.number,
+                    "results": RepasseSerializer(page, many=True).data,
+                }
+            )
+
+        if not request.user.has_perm("financeiro.add_repasse"):
+            return Response({"detail": "Sem permissao para criar repasse."}, status=status.HTTP_403_FORBIDDEN)
+
+        serializer = RepasseCreateSerializer(data=request.data, context={"request": request, "loja": loja})
+        serializer.is_valid(raise_exception=True)
+        repasse = serializer.save()
+        return Response(RepasseSerializer(repasse).data, status=status.HTTP_201_CREATED)
 
     @action(detail=True, methods=["post"], url_path="replicar-qrcode")
     @extend_schema(

--- a/docs/API.md
+++ b/docs/API.md
@@ -62,6 +62,22 @@ Ou, quando ha validacao de formularios compostos:
 
 Rotas baseadas em `LojaViewSet`.
 
+### Permissoes de acesso em lojas
+
+- `list` e `retrieve`: exige `vendas.view_loja`
+- `create`: exige `vendas.add_loja`
+- `update`/`partial_update` e `replicar-qrcode`: exige `vendas.change_loja`
+- `destroy`: exige `vendas.delete_loja`
+- `repasses` (`GET`/`POST`): exige respectivamente `financeiro.view_repasse` e `financeiro.add_repasse`
+
+Regra de escopo (quem pode entrar/ver cada loja):
+
+- Se o usuario **nao** tem `vendas.can_view_all_stores`, a API restringe a visualizacao para:
+  - `loja_id` da sessao (quando existir), ou
+  - lojas associadas em `user.lojas`, ou
+  - `user.loja` (fallback)
+- Se nao houver vinculo, a listagem retorna vazia.
+
 ### `GET /api/lojas/`
 
 Lista lojas visiveis para o usuario.
@@ -90,18 +106,37 @@ Query params:
 
 Resposta inclui:
 
-- `loja`
+- `loja` (inclui tambem `usuarios_detalhes` e `gerentes_detalhes`)
 - `contrato`
-- `repasses` (paginado)
+- `repasses` (paginado; vazio quando o usuario nao possui `financeiro.view_repasse`)
 - `vendas` (paginado)
-- `repasse_status_list`
+- `repasse_status_list` (vazio sem permissao de visualizar repasse)
 - `repasse_atrasados`
 - `kpi_valor_repasse`
 - `kpi`
+- `acessos` (flags de permissao: `pode_editar_loja`, `pode_criar_repasse`, `pode_ver_repasse`, `can_view_all_stores`)
 
 ### `PUT/PATCH /api/lojas/{id}/`
 
 Atualiza loja.
+
+### `GET /api/lojas/{id}/repasses/`
+
+Lista repasses da loja (paginado).
+
+- Exige permissao `financeiro.view_repasse`.
+- Query param: `repasse_page` (opcional).
+
+### `POST /api/lojas/{id}/repasses/`
+
+Cria repasse para a loja.
+
+- Exige permissao `financeiro.add_repasse`.
+- Payload:
+  - `valor`
+  - `data`
+  - `status` (`pendente`, `pago`, `cancelado`)
+  - `observacao` (opcional)
 
 ### `POST /api/lojas/{id}/replicar-qrcode/`
 


### PR DESCRIPTION
### Motivation

- Centralizar na API as informações e regras exibidas na página de detalhes da loja, incluindo quem pode ver/criar repasses e quais lojas o usuário consegue acessar. 
- Expor repasses via API com controle de permissões para espelhar o comportamento da interface web. 
- Atualizar a documentação para refletir os novos campos e endpoints.

### Description

- Enriquecido o `LojaSerializer` com `usuarios_detalhes` e `gerentes_detalhes` (id, nome e email) para fornecer os dados mostrados na UI. 
- Adicionado `RepasseCreateSerializer` para criação de `Repasse` via API e novo action `repasses` em `LojaViewSet` para `GET /api/lojas/{id}/repasses/` e `POST /api/lojas/{id}/repasses/` com validação de permissões. 
- Tornado o `retrieve` de `LojaViewSet` permission-aware para ocultar repasses/status quando o usuário não tem `financeiro.view_repasse` e incluídas flags em `acessos` (`pode_editar_loja`, `pode_criar_repasse`, `pode_ver_repasse`, `can_view_all_stores`). 
- Atualizada `LojaPermission` para autorizar a nova action `repasses`, adicionada documentação em `docs/API.md` e testes de API em `api/tests.py` cobrindo flags e comportamento de permissões. 

### Testing

- Código compilado com `python -m py_compile api/views.py api/serializers.py api/permissions.py api/tests.py` com sucesso. 
- Testes de integração executados localmente com `python manage.py test api.tests` não concluíram no ambiente atual por falta de configuração (`DB_USED` não definido) e dependência `rest_framework` indisponível, logo os novos testes foram adicionados mas não foram executados com sucesso neste container.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d311c8844832a87d243ddf7e69d1d)