### PR TITLE
Add overdue clients KPI to dashboard PDF

### DIFF
--- a/vendas/templates/dash/relatorio_pdf.html
+++ b/vendas/templates/dash/relatorio_pdf.html
@@ -162,6 +162,12 @@
         <!-- Resumo Geral -->
         <div class="loja-section">
             <h2 class="loja-title">Resumo Geral</h2>
+            <div class="kpi-grid">
+                <div class="kpi-card">
+                    <h4>Clientes Inadimplentes</h4>
+                    <div class="value danger">{{ clientes_vencidos|default:"0" }}</div>
+                </div>
+            </div>
             <table class="summary-table">
                 <thead>
                     <tr>
@@ -170,6 +176,7 @@
                         <th>Parcelas</th>
                         <th>Pagas</th>
                         <th>Vencidas</th>
+                        <th>Clientes Inadimplentes</th>
                         <th>A Vencer</th>
                         <th>Valor Total</th>
                         <th>Repasses</th>
@@ -183,6 +190,7 @@
                         <td>{{ dados.total_parcelas }}</td>
                         <td>{{ dados.parcelas_pagas }}<br><small class="currency">R$ {{ dados.total_pagas|floatformat:2 }}</small></td>
                         <td>{{ dados.parcelas_vencidas }}<br><small class="currency">R$ {{ dados.total_vencidas|floatformat:2 }}</small></td>
+                        <td>{{ dados.clientes_vencidos|default:"0" }}</td>
                         <td>{{ dados.parcelas_a_vencer }}<br><small class="currency">R$ {{ dados.total_a_vencer|floatformat:2 }}</small></td>
                         <td class="currency">R$ {{ dados.valor_total_parcelas|floatformat:2 }}</td>
                         <td class="currency">R$ {{ dados.total_repasses|floatformat:2 }}</td>
@@ -226,6 +234,11 @@
                 <div class="kpi-card">
                     <h4>Parcelas Vencidas</h4>
                     <div class="value danger">{{ dados.parcelas_vencidas }}</div>
+                </div>
+
+                <div class="kpi-card">
+                    <h4>Clientes Inadimplentes</h4>
+                    <div class="value danger">{{ dados.clientes_vencidos|default:"0" }}</div>
                 </div>
                 
                 <div class="kpi-card">

--- a/vendas/views.py
+++ b/vendas/views.py
@@ -3812,6 +3812,7 @@ class DashboardReportPDFView(PermissionRequiredMixin, View):
 
         # Dados por loja
         dados_por_loja = {}
+        total_clientes_vencidos_ids = set()
         
         for loja in lojas:
             # Repasses and vendas counts rely on the period's sales (not installments)
@@ -3825,9 +3826,11 @@ class DashboardReportPDFView(PermissionRequiredMixin, View):
             # Calcular KPIs para esta loja
             total_de_parcelas_vencidas = total_de_parcelas_pagas = total_de_parcelas_a_vencer = 0
             total_pagas = total_vencidas = total_a_vencer = 0
+            clientes_vencidos_ids = set()
 
             for venda_id in vendas_ativas_IDs:
                 parcelas = parcelas_por_venda.get(venda_id, [])
+                venda = parcelas[0].pagamento.venda if parcelas else None
                 
                 parcelas_vencidas = [p for p in parcelas if p.data_vencimento < timezone.now().date() and not p.pago and not p.pagamento_efetuado]
                 parcelas_pagas = [p for p in parcelas if p.pago and not p.pagamento_efetuado]
@@ -3840,6 +3843,10 @@ class DashboardReportPDFView(PermissionRequiredMixin, View):
                 total_vencidas += sum(p.valor for p in parcelas_vencidas)
                 total_pagas += sum(p.valor_pago_efetivo for p in parcelas_pagas)
                 total_a_vencer += sum(p.valor for p in parcelas_a_vencer)
+
+                if parcelas_vencidas and venda and venda.cliente_id:
+                    clientes_vencidos_ids.add(venda.cliente_id)
+                    total_clientes_vencidos_ids.add(venda.cliente_id)
 
             # Calcular desativados para esta loja
             parcelas_desativadas = Parcela.objects.filter(
@@ -3872,6 +3879,7 @@ class DashboardReportPDFView(PermissionRequiredMixin, View):
                 'total_parcelas': total_de_parcelas_vencidas + total_de_parcelas_pagas + total_de_parcelas_a_vencer,
                 'parcelas_pagas': total_de_parcelas_pagas,
                 'parcelas_vencidas': total_de_parcelas_vencidas,
+                'clientes_vencidos': len(clientes_vencidos_ids),
                 'parcelas_a_vencer': total_de_parcelas_a_vencer,
                 'total_pagas': total_pagas,
                 'total_vencidas': total_vencidas,
@@ -3886,6 +3894,7 @@ class DashboardReportPDFView(PermissionRequiredMixin, View):
 
         return {
             'dados_por_loja': dados_por_loja,
+            'clientes_vencidos': len(total_clientes_vencidos_ids),
             'data_geracao': timezone.now(),
             'usuario': self.request.user,
         }


### PR DESCRIPTION
Display a new "Clientes Inadimplentes" KPI in the PDF dashboard: added a kpi-card and table column in relatorio_pdf.html (defaults to "0" when empty). Update views to compute unique clients with overdue installments by collecting cliente_ids into per-store and global sets, expose per-store 'clientes_vencidos' and overall 'clientes_vencidos' in the template context, and guard against empty parcelas when resolving the related venda.