### PR TITLE
Use requestSubmit and remove duplicate hidden field

### DIFF
--- a/vendas/templates/cliente/form_cliente.html
+++ b/vendas/templates/cliente/form_cliente.html
@@ -2152,6 +2152,10 @@
           const form = document.getElementById('clienteForm');
           const aprovarUrl = this.getAttribute('data-url');
           
+          form.querySelectorAll('input[name="aprovar_apos_salvar"]').forEach(function(input) {
+            input.remove();
+          });
+
           // Cria um campo hidden para identificar que é uma aprovação
           const hiddenField = document.createElement('input');
           hiddenField.type = 'hidden';
@@ -2159,8 +2163,15 @@
           hiddenField.value = aprovarUrl;
           form.appendChild(hiddenField);
           
-          // Submete o formulário
-          form.submit();
+          // Usa o fluxo normal de submit para manter validações e handlers ativos.
+          if (form.requestSubmit) {
+            form.requestSubmit();
+          } else {
+            const submitEvent = new Event('submit', { bubbles: true, cancelable: true });
+            if (form.dispatchEvent(submitEvent) && form.checkValidity()) {
+              form.submit();
+            }
+          }
         });
       }
     });

--- a/vendas/templates/cliente/form_cliente_imei_telefone.html
+++ b/vendas/templates/cliente/form_cliente_imei_telefone.html
@@ -530,6 +530,10 @@
           const form = document.getElementById('clienteForm');
           const aprovarUrl = this.getAttribute('data-url');
           
+          form.querySelectorAll('input[name="aprovar_apos_salvar"]').forEach(function(input) {
+            input.remove();
+          });
+
           // Cria um campo hidden para identificar que é uma aprovação
           const hiddenField = document.createElement('input');
           hiddenField.type = 'hidden';
@@ -537,8 +541,15 @@
           hiddenField.value = aprovarUrl;
           form.appendChild(hiddenField);
           
-          // Submete o formulário
-          form.submit();
+          // Usa o fluxo normal de submit para manter validações e handlers ativos.
+          if (form.requestSubmit) {
+            form.requestSubmit();
+          } else {
+            const submitEvent = new Event('submit', { bubbles: true, cancelable: true });
+            if (form.dispatchEvent(submitEvent) && form.checkValidity()) {
+              form.submit();
+            }
+          }
         });
       }
     });


### PR DESCRIPTION
Remove any existing inputs named 'aprovar_apos_salvar' before appending a new hidden approval field, and submit the form via form.requestSubmit() when available to preserve native validation and event handlers. Add a fallback that dispatches a submit event and checks validity before calling form.submit(). Changes applied to form_cliente.html and form_cliente_imei_telefone.html to avoid duplicate hidden inputs and keep validation/handlers intact.