### PR TITLE
Rename sem_conexao to Desabilitado and include it

### DIFF
--- a/financeiro/forms.py
+++ b/financeiro/forms.py
@@ -181,7 +181,7 @@ class RelatorioContasAReceberForm(forms.Form):
             ('quitado', 'Quitado'),
             ('lembrete', 'Lembrete'),
             ('flag_atrasado', 'Cobrança'),
-            ('sem_conexao', 'Sem conexão'),
+            ('sem_conexao', 'Desabilitado'),
             ('roubo', 'Roubo'),
             ('devolucao', 'Devolução'),
             ('todos', 'Todos')
@@ -316,7 +316,7 @@ class RelatorioContasAReceberAvancadoForm(forms.Form):
             ('lembrete','Lembrete'),
             ('bo','BO'),
             ('flag_atrasado','Cobrança'),
-            ('sem_conexao','Sem conexão'),
+            ('sem_conexao','Desabilitado'),
             ('roubo','Roubo'),
             ('bloqueado','Bloquear Aparelho'),
             ('desativado','Desativar Cliente'),

--- a/financeiro/templates/contas_a_receber/folha.html
+++ b/financeiro/templates/contas_a_receber/folha.html
@@ -167,6 +167,7 @@
             <tr class="
             {% if conta.desativado %}table-secondary
             {% elif conta.bloqueado %}table-purple
+            {% elif conta.sem_conexao %}table-secondary
             {% elif conta.sem_contato %}table-indigo
             {% elif conta.mais_prazo %}table-teal
             {% elif conta.com_parcela_atrasada %}table-danger
@@ -193,6 +194,9 @@
             {% if conta.bloqueado %}
                 <span class="badge badge-purple">BLOQUEADO</span>
             {% endif %}
+            {% if conta.sem_conexao %}
+                <span class="badge badge-secondary">DESABILITADO</span>
+            {% endif %}
             {% if conta.sem_contato %}
                 <span class="badge badge-indigo">SEM CONTATO</span>
             {% endif %}
@@ -214,7 +218,7 @@
             {% if conta.flag_atrasado %}
                 <span class="badge badge-orange">COBRANÇA</span>
             {% endif %}
-            {% if not conta.desativado and not conta.bloqueado and not conta.sem_contato and not conta.mais_prazo and not conta.com_parcela_atrasada and not conta.com_pagamento_pendente and not conta.pago_dentro_prazo and not conta.todas_parcelas_pagas and not conta.flag_atrasado %}
+            {% if not conta.desativado and not conta.bloqueado and not conta.sem_conexao and not conta.sem_contato and not conta.mais_prazo and not conta.com_parcela_atrasada and not conta.com_pagamento_pendente and not conta.pago_dentro_prazo and not conta.todas_parcelas_pagas and not conta.flag_atrasado %}
                 <span class="badge badge-success">ATIVO</span>
             {% endif %}
             </td>

--- a/financeiro/templates/contas_a_receber/folha_relatorio_avancado.html
+++ b/financeiro/templates/contas_a_receber/folha_relatorio_avancado.html
@@ -25,6 +25,9 @@
   {% if data_inicio and data_fim %}
   <h3>Período: {{ data_inicio }} a {{ data_fim }}</h3>
   {% endif %}
+  {% if situacoes %}
+  <h3>Situações: {{ situacoes|join:", " }}</h3>
+  {% endif %}
   <table>
     <thead>
       <tr>
@@ -52,7 +55,7 @@
         <td>
           {% if p.bo %}<span class="badge">BO</span>{% endif %}
           {% if p.flag_atrasado %}<span class="badge">Cobrança</span>{% endif %}
-          {% if p.sem_conexao %}<span class="badge">Sem conexão</span>{% endif %}
+          {% if p.sem_conexao %}<span class="badge">Desabilitado</span>{% endif %}
           {% if p.roubo %}<span class="badge">Roubo</span>{% endif %}
           {% if p.bloqueado %}<span class="badge">Bloqueado</span>{% endif %}
           {% if p.desativado %}<span class="badge">Desativado</span>{% endif %}

--- a/financeiro/views.py
+++ b/financeiro/views.py
@@ -638,6 +638,7 @@ class RelatorioContasAReceberView(BaseView, PermissionRequiredMixin, TemplateVie
 class FolhaRelatorioContasAReceberView(BaseView, PermissionRequiredMixin, TemplateView):
     template_name = 'contas_a_receber/folha.html'
     permission_required = 'vendas.can_genarate_report_payments'
+    STATUS_LABELS = dict(RelatorioContasAReceberForm.base_fields['status'].choices)
 
     def get_context_data(self, **kwargs):
         data_inicio = self.request.GET.get('data_inicial')
@@ -686,7 +687,7 @@ class FolhaRelatorioContasAReceberView(BaseView, PermissionRequiredMixin, Templa
                 context['list_by_parcelas'] = True
                 context['parcelas'] = parcelas_list
                 context['lojas'] = lojas_qs.values_list('nome', flat=True) if lojas_qs else []
-                context['status_list'] = status_list
+                context['status_list'] = [self.STATUS_LABELS.get(status, status) for status in status_list]
                 context['data_inicio'] = data_inicio_dt
                 context['data_fim'] = data_final_dt
 
@@ -799,7 +800,8 @@ class FolhaRelatorioContasAReceberView(BaseView, PermissionRequiredMixin, Templa
                     pagamentos_qs = pagamentos_qs.filter(
                         Q(proximo_vencimento__isnull=False, proximo_vencimento__gte=data_inicio_dt, proximo_vencimento__lt=data_final_dt_plus) |
                         Q(ultimo_vencimento__isnull=False, ultimo_vencimento__gte=data_inicio_dt, ultimo_vencimento__lt=data_final_dt_plus) |
-                        Q(ultimo_pagamento__isnull=False, ultimo_pagamento__gte=data_inicio_dt, ultimo_pagamento__lt=data_final_dt_plus)
+                        Q(ultimo_pagamento__isnull=False, ultimo_pagamento__gte=data_inicio_dt, ultimo_pagamento__lt=data_final_dt_plus) |
+                        Q(sem_conexao=True)
                     ).distinct()
                 else:
                     # Se não filtrar por status, usar proximo_vencimento por padrão
@@ -838,7 +840,7 @@ class FolhaRelatorioContasAReceberView(BaseView, PermissionRequiredMixin, Templa
         context = super().get_context_data(**kwargs)
         context['contas_a_receber'] = contas_a_receber
         context['lojas'] = Loja.objects.filter(id__in=lojas).values_list('nome', flat=True)
-        context['status_list'] = status_list
+        context['status_list'] = [self.STATUS_LABELS.get(status, status) for status in status_list]
         context['data_inicio'] = datetime.strptime(data_inicio, "%Y-%m-%d").date() if data_inicio else None
         context['data_fim'] = datetime.strptime(data_fim, "%Y-%m-%d").date() if data_fim else None
         context['total_atrasado'] = total_atrasado
@@ -864,6 +866,7 @@ class RelatorioContasAReceberAvancadoView(BaseView, PermissionRequiredMixin, Tem
 class FolhaRelatorioContasAReceberAvancadoView(BaseView, PermissionRequiredMixin, TemplateView):
     template_name = 'contas_a_receber/folha_relatorio_avancado.html'
     permission_required = 'vendas.can_genarate_report_payments'
+    SITUACAO_LABELS = dict(RelatorioContasAReceberAvancadoForm.base_fields['situacoes'].choices)
 
     def get_context_data(self, **kwargs):
         data_inicio = self.request.GET.get('data_inicial')
@@ -923,6 +926,7 @@ class FolhaRelatorioContasAReceberAvancadoView(BaseView, PermissionRequiredMixin
         context['contas'] = contas
         context['data_inicio'] = data_inicio
         context['data_fim'] = data_fim
+        context['situacoes'] = [self.SITUACAO_LABELS.get(situacao, situacao) for situacao in situacoes]
         return context
 
 class RelatorioSaidaView(BaseView, PermissionRequiredMixin, TemplateView):


### PR DESCRIPTION
Update labels and handling for the sem_conexao status across forms, templates and views. Changes include:
- Change choice label for 'sem_conexao' to 'Desabilitado' in both RelatorioContasAReceberForm and RelatorioContasAReceberAvancadoForm.
- Update folha.html to apply a table-secondary row class and show a 'DESABILITADO' badge when conta.sem_conexao is true; include sem_conexao in the active-status check so it no longer displays as ATIVO.
- Update folha_relatorio_avancado.html to display situations header when provided and show 'Desabilitado' instead of 'Sem conexão' for sem_conexao badges.
- In views, add STATUS_LABELS and SITUACAO_LABELS mappings to resolve human-readable labels from form choices and use them for status/situations lists in context. Also include sem_conexao in the queryset filters so records with sem_conexao are returned when appropriate. These changes ensure consistent labeling and correct filtering/display behavior for the sem_conexao/Desabilitado status.